### PR TITLE
Issue #13: Create publisher

### DIFF
--- a/director.py
+++ b/director.py
@@ -1,0 +1,8 @@
+"""
+Example file/stubbed to show how publisher is used.
+"""
+
+from publisher import Publisher
+
+
+Publisher.move(1, 2, 3)

--- a/manual_interface.py
+++ b/manual_interface.py
@@ -1,0 +1,8 @@
+"""
+Example file/stubbed to show how publisher is used.
+"""
+
+from publisher import Publisher
+
+
+Publisher.rotate(45)

--- a/mock_operator.py
+++ b/mock_operator.py
@@ -1,5 +1,6 @@
 import stomp
 import time
+from publisher import INSTRUCTIONS_DESTINATION
 
 class MyListener(stomp.ConnectionListener):
     def on_error(self, frame):
@@ -11,6 +12,6 @@ class MyListener(stomp.ConnectionListener):
 conn = stomp.Connection()
 conn.set_listener(name='My listener', listener=MyListener())
 conn.connect('admin', 'admin', wait=True)
-conn.subscribe(destination='/queue/test', id=1)
+conn.subscribe(destination=INSTRUCTIONS_DESTINATION, id=1)
 time.sleep(10)
 conn.disconnect()

--- a/pub.py
+++ b/pub.py
@@ -1,6 +1,0 @@
-import stomp
-
-conn = stomp.Connection()
-conn.connect('admin', 'admin', wait=True)
-conn.send(body='Hello, world!', destination='/queue/test')
-conn.disconnect()

--- a/publisher.py
+++ b/publisher.py
@@ -5,6 +5,11 @@ INSTRUCTIONS_DESTINATION = 'queue/instructions'
 
 
 class Connection:
+    """
+    The publisher class does not have an initialization since it is a static class.
+    This class exists to initialize a single connection instance that is used by the
+    publisher. Also contains a function that is used to publish messages.
+    """
     def __init__(self):
         self.connection = stomp.Connection()
         self.connection.connect('admin', 'admin', wait=True)
@@ -14,6 +19,9 @@ class Connection:
 
 
 class Publisher:
+    """
+    A static class that is used to publish instructions to the operator.
+    """
     connection = Connection()
 
     @staticmethod

--- a/publisher.py
+++ b/publisher.py
@@ -1,0 +1,28 @@
+import stomp
+
+
+INSTRUCTIONS_DESTINATION = 'queue/instructions'
+
+
+class Connection:
+    def __init__(self):
+        self.connection = stomp.Connection()
+        self.connection.connect('admin', 'admin', wait=True)
+
+    def publish(self, body, destination):
+        self.connection.send(body=body, destination=destination)
+
+
+class Publisher:
+    connection = Connection()
+
+    @staticmethod
+    def move(x, y, z):
+        # Placeholder message
+        Publisher.connection.publish(f'Move to {x}, {y}, {z}', destination=INSTRUCTIONS_DESTINATION)
+
+    @staticmethod
+    def rotate(deg):
+        # Placeholder message
+        Publisher.connection.publish(f'Rotate {deg}', destination=INSTRUCTIONS_DESTINATION)
+


### PR DESCRIPTION
Create a static Publisher class that is used by the Director and the Manual Interface. 
Stub files for Director and Manual interface to show how they would use the Publisher.

To run it yourself:
- Follow the README to get your environment set up.
  - Create venv, install dependencies, and get activemq running
- Run `mock_operator.py`
- While `mock_operator.py` is running run `director.py` and/or `manual_interface.py`

closes #15 
closes #13