### PR TITLE
stop director from pulling frames

### DIFF
--- a/directors/base_director.py
+++ b/directors/base_director.py
@@ -15,17 +15,17 @@ class BaseDirector(ABC):
     def __init__(self, tracker: Tracker, scheduler: Scheduler | None = None):
         self.tracker = tracker
         self.scheduler = scheduler
+        self.frame_shape = self.tracker.get_frame_shape()
 
     # Processes the bounding box and sends commands
     @abstractmethod
-    def process_frame(self, bounding_box: list, frame):
+    def process_frame(self, bounding_box: list, frame_shape):
         raise NotImplementedError("Subclasses must implement this method.")
 
     def track_obj(self):
-        # TODO: remove the usage of frames in this function because all it does is check the frame size
-        bbox, frame = self.tracker.get_bbox(), self.tracker.get_frame()
+        bbox = self.tracker.get_bbox()
         if bbox is not None:
-            return self.process_frame(bbox, frame)
+            return self.process_frame(bbox, self.frame_shape)
 
     def start_auto_control(self):
         if self.scheduler is not None:

--- a/directors/continuous_director.py
+++ b/directors/continuous_director.py
@@ -15,15 +15,14 @@ class ContinuousDirector(BaseDirector):
     movement_detection_start_time = None
 
     # This method is called to process each frame
-    def process_frame(self, bounding_box: list, frame, is_director_running):
+    def process_frame(self, bounding_box: list, frame_shape, is_director_running):
         """
         Based on received bounding box, this method tells the arm where to move the keep the subject in the acceptable box..
         It does this by continuously sending polar pan start and a direction until the subject is in the acceptable box.
         Then it sends a polar pan stop.
         """
-        frameOpenCV = frame.copy()
-        frame_height = frameOpenCV.shape[0]
-        frame_width = frameOpenCV.shape[1]
+        frame_height = frame_shape[0]
+        frame_width = frame_shape[1]
 
         if len(bounding_box) == 0:
             return

--- a/directors/discrete_director.py
+++ b/directors/discrete_director.py
@@ -20,13 +20,12 @@ class DiscreteDirector(BaseDirector):
     movement_detection_start_time = None
 
     # This method is called to process each frame
-    def process_frame(self, bounding_box: list, frame, is_director_running):
+    def process_frame(self, bounding_box: list, frame_shape, is_director_running):
         # Do something with the frame
 
         # Getting frame width and frame height
-        frameOpenCV = frame.copy()
-        frame_height = frameOpenCV.shape[0]
-        frame_width = frameOpenCV.shape[1]
+        frame_height = frame_shape[0]
+        frame_width = frame_shape[1]
 
         if len(bounding_box) == 0:
             return

--- a/tracking/tracker.py
+++ b/tracking/tracker.py
@@ -138,10 +138,11 @@ class Tracker:
         self.hasNewFrame = True
         return self.hasNewFrame, self._frame
 
-    def get_frame(self):
-        res = (self.hasNewFrame, self._frame)
+    def get_frame_shape(self):
         self.hasNewFrame = False
-        return res
+        frame_height = self._frame.shape[0]
+        frame_width = self._frame.shape[1]
+        return (frame_height, frame_width)
 
     def get_bbox(self):
         return self._bboxes


### PR DESCRIPTION
# Description
-changes tracker's get_frame() function to get_frame_shape(), since this is the only info that director needs and this function is never used elsewhere.
-changed all directors to call get_frame_shape() once upon initialization and save the frame shape for all future bounding box calculations, rather than getting it by pulling frames every iteration
-closes issue #116 

# Metrics
- PR Confidence value(1 ~ 5): 4
