### PR TITLE
Updated Intel mac runner label

### DIFF
--- a/.github/workflows/pyinstaller_build.yaml
+++ b/.github/workflows/pyinstaller_build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # pull_request: # Uncomment this to test the action in your PR if you change this file
 
 jobs:
   build:


### PR DESCRIPTION
# Description
Changed from macos-latest-large to macos-15-intel
# Metrics
- PR Confidence value(1 ~ 5): 3
Not sure if the runners we are now using are as free as we previously thought.
