### PR TITLE
[FEAT] Add AGPL 3.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,7 +629,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Commander - allows robot arms to be controlled via custom UI and integrate computer vision software.
+    Commander - allows robot arms to be repurposed as camera arms.
     Copyright (C) 2026 Talos RIT
 
     This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
# Description
This change adds AGPL 3.0 license to the project.

The license decision was made due to our dependency, YOLO, licensed under AGPL 3.0 license which is a copyleft license and requires us to also use that license or more restrictive license. We could alternatively drop the dependency and create an extension code that is licensed differently based on the vision model used, but that is more work and easier for us to just license as a copyleft license for now. We can drop the license to a MIT later when that change is made. For the time being we will place a license to allow contributions from contributors and follow community standards/open source standards. 

# Metrics
- PR Confidence value(1 ~ 5): 4
