### PR TITLE
Add launch configs and uv sync tasks for VS Code Python debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Tkinter UI - No Extras",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "talos.py",
+            "preLaunchTask": "uv sync base",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+        {
+            "name": "TUI - No Extras",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "talos.py",
+            "args": ["-t"],
+            "preLaunchTask": "uv sync base",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+        {
+            "name": "Tkinter UI - All Extras",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "talos.py",
+            "preLaunchTask": "uv sync all",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+        {
+            "name": "TUI - All Extras",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "talos.py",
+            "args": ["-t"],
+            "preLaunchTask": "uv sync all",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "uv sync base",
+            "type": "shell",
+            "command": "uv",
+            "args": ["sync"],
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "uv sync all",
+            "type": "shell",
+            "command": "uv",
+            "args": ["sync", "--all-extras"],
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# Description
Add launch configs for starting the debugger in VS Code. This should make starting up the debugger easier.

# Metrics
- PR Confidence value(1 ~ 5): 5
