### PR TITLE
Added deepwiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # camera_arm
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/talos-rit/commander)
 
 Allows robot arms to be repurposed as camera arms.
 


### PR DESCRIPTION
# Description
Added a badge to the README that takes you directly to the DeepWiki for commander. This badge also lets other developers know that we had DeepWiki index our repository and create supplemental documentation for the entire repo.

# Metrics
- PR Confidence value(1 ~ 5): 5
